### PR TITLE
account-manager - use updated class from addfwrule

### DIFF
--- a/lib/account_manager.rb
+++ b/lib/account_manager.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 # setup the account specific API-Client key/secret and
 # save these in a dot file like ~/.halo Reference the
 # location as a ENV param instead of "hardcoding"
@@ -24,6 +26,9 @@
 # in your ~/.bash_profile Should look something like
 # HALO_API_KEY_FILE="/home/ehoffmann/.halo"
 # export HALO_API_KEY_FILE
+#
+# Alternatively, set the environment variables for
+# HALO_ID and HALO_SECRET_KEY.
 
 class AccountManager
   attr_reader :api_keys
@@ -36,8 +41,19 @@ class AccountManager
     @api_keys ||= load_accounts
   end
 
+  def load_from_environment
+    raise "[ERROR] loading api_keys: #{e}" and exit if ENV['HALO_ID'].nil? && ENV['HALO_SECRET_KEY'].nil?
+    {
+      'halo' => {
+        'key_id' => ENV['HALO_ID'],
+        'secret_key' => ENV['HALO_SECRET_KEY'],
+        'grid' => ENV['HALO_GRID']
+      }
+    }
+  end
+
   def load_accounts
-    YAML.load_file(@config_file)
+    @config_file.nil? ? load_from_environment : YAML.load_file(@config_file)
   rescue => e
     raise "[ERROR] loading api_keys: #{e}" and exit
   end

--- a/spec/account_manager_spec.rb
+++ b/spec/account_manager_spec.rb
@@ -1,28 +1,62 @@
 require_relative 'spec_helper'
 
 describe AccountManager do
-  before do
-    @fake_accounts = {
-      'halo1' => {
-        'key_id' => 'some_key_id',
-        'secret_key' => 'some_secret_key'
-      },
-      'halo2' => {
-        'key_id' => 'some_key_id2',
-        'secret_key' => 'some_secret_key2',
-        'grid' => 'api.somegrid.local'
+  describe "load keys from ENV" do
+    before :all do
+      ENV['HALO_ID'] = nil
+      ENV['HALO_SECRET_KEY'] = nil
+      ENV['HALO_GRID'] = nil
+      ENV['HALO_API_KEY_FILE'] = nil
+    end
+
+    it "uses existing API keys" do
+      fake_account = {
+        'halo' => {
+          'key_id' => 'some_key_id',
+          'secret_key' => 'some_secret_key',
+          'grid' => nil
+        }
       }
-    }
+      ENV['HALO_ID'] = 'some_key_id'
+      ENV['HALO_SECRET_KEY'] = 'some_secret_key'
+      api_keys = AccountManager.new.api_keys
+      expect(api_keys).to eq(fake_account)
+    end
+
   end
 
-  it "exits when no config file given and not environment specified" do
-    ENV['HALO_API_KEY_FILE'] = nil
-    am = AccountManager.new
-    expect { am.api_keys }.to raise_error RuntimeError
-  end
+  describe "load keys from halo yaml file" do
+    before do
+      @fake_accounts = {
+        'halo1' => {
+          'key_id' => 'some_key_id',
+          'secret_key' => 'some_secret_key'
+        },
+        'halo2' => {
+          'key_id' => 'some_key_id2',
+          'secret_key' => 'some_secret_key2',
+          'grid' => 'api.somegrid.local'
+        }
+      }
+    end
 
-  it "loads locally specified config file" do
-    api_keys = AccountManager.new('./spec/fixtures/halo_accounts.yml').api_keys
-    expect(api_keys).to eq(@fake_accounts)
+    it "exits when no config file given and not environment specified" do
+      ENV['HALO_API_KEY_FILE'] = nil
+      ENV['HALO_ID'] = nil
+      ENV['HALO_SECRET_KEY'] = nil
+      am = AccountManager.new
+      expect { am.api_keys }.to raise_error RuntimeError
+    end
+
+    it "loads locally specified config file" do
+      api_keys = AccountManager.new('./spec/fixtures/halo_accounts.yml').api_keys
+      expect(api_keys).to eq(@fake_accounts)
+    end
+
+    it "loads locally specified config file" do
+      ENV['HALO_API_KEY_FILE'] = './spec/fixtures/halo_accounts.yml'
+      api_keys = AccountManager.new.api_keys
+      expect(api_keys).to eq(@fake_accounts)
+    end
   end
 end


### PR DESCRIPTION
add updates from add fw rule to account manager allowing env variables to be used instead of conf file